### PR TITLE
feat(home): add promo carousel and blog section to home page

### DIFF
--- a/lib/modules/chat/views/chatting_page.dart
+++ b/lib/modules/chat/views/chatting_page.dart
@@ -17,7 +17,7 @@ class ChattingPage extends StatelessWidget {
           Expanded(
             flex: 8,
             child: ListView.builder(
-                itemCount: 8,
+                itemCount: 5,
                 itemBuilder: (BuildContext context, int index) {
                   return MessageCard(
                       sender: 'John Doe',

--- a/lib/modules/home/controllers/promo_controller.dart
+++ b/lib/modules/home/controllers/promo_controller.dart
@@ -1,0 +1,18 @@
+import 'package:get/get.dart';
+
+class PromoController extends GetxController {
+  // Current page index for the carousel
+  final RxInt currentIndex = 0.obs;
+  
+  // List of promo images (you can replace these with your actual promo images)
+  final List<String> promoImages = [
+    'https://t4.ftcdn.net/jpg/01/15/04/39/360_F_115043913_g00I2WhOKYresf7JId9GTTnNy50FBDRi.jpg',
+    'https://img.freepik.com/free-vector/special-offer-creative-sale-banner-design_1017-16284.jpg',
+    'https://img.freepik.com/free-vector/gradient-sale-background_23-2149050986.jpg',
+  ];
+  
+  // Method to update the current index when carousel page changes
+  void updateIndex(int index) {
+    currentIndex.value = index;
+  }
+}

--- a/lib/modules/home/views/home_page.dart
+++ b/lib/modules/home/views/home_page.dart
@@ -3,7 +3,9 @@ import 'package:flutter/services.dart';
 import 'package:function_mobile/modules/auth/controllers/auth_controller.dart';
 import 'package:function_mobile/modules/home/controllers/home_controller.dart';
 import 'package:function_mobile/modules/home/controllers/search_filter_controller.dart';
+import 'package:function_mobile/modules/home/widgets/build_blog.dart';
 import 'package:function_mobile/modules/home/widgets/build_header.dart';
+import 'package:function_mobile/modules/home/widgets/build_promo.dart';
 import 'package:function_mobile/modules/home/widgets/build_recommendation.dart';
 import 'package:function_mobile/modules/home/widgets/search_container.dart';
 import 'package:get/get.dart';
@@ -90,6 +92,16 @@ class HomePage extends StatelessWidget {
                 padding: const EdgeInsets.all(16),
                 child: buildRecommendation(context, homeController),
               ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: buildPromo(),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: buildBlog(),
+              ),
+              const SizedBox(
+                  height: 50), // Add some space at the bottom of the conten
             ],
           ),
         ),

--- a/lib/modules/home/widgets/build_blog.dart
+++ b/lib/modules/home/widgets/build_blog.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:function_mobile/common/widgets/images/network_image.dart';
+import 'package:get/get.dart';
+
+Widget buildBlog() {
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(
+        'Blog',
+        style: Get.theme.textTheme.headlineSmall,
+      ),
+      const SizedBox(height: 10),
+      SizedBox(
+          height: 220,
+          child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              itemCount: 5,
+              itemBuilder: (BuildContext context, int index) {
+                return Container(
+                    margin: EdgeInsets.only(right: 16),
+                    width: 500,
+                    height: 200,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(16),
+                      child: NetworkImageWithLoader(
+                          imageUrl:
+                              'https://picsum.photos/seed/picsum/500/200'),
+                    ));
+              })),
+    ],
+  );
+}

--- a/lib/modules/home/widgets/build_promo.dart
+++ b/lib/modules/home/widgets/build_promo.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:function_mobile/common/widgets/images/network_image.dart';
+import 'package:get/get.dart';
+import 'package:carousel_slider/carousel_slider.dart';
+import 'package:function_mobile/modules/home/controllers/promo_controller.dart';
+
+Widget buildPromo() {
+  // Lazily initialize the controller so it's only created when needed
+  final PromoController controller = Get.put(PromoController());
+
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            'Promo',
+            style: Get.theme.textTheme.headlineSmall,
+          ),
+        ],
+      ),
+      const SizedBox(height: 10),
+      CarouselSlider.builder(
+        itemCount: controller.promoImages.length,
+        options: CarouselOptions(
+          height: 220,
+          viewportFraction: 1,
+          enlargeCenterPage: true,
+          autoPlay: true,
+          autoPlayInterval: const Duration(seconds: 8),
+          autoPlayAnimationDuration: const Duration(milliseconds: 800),
+          onPageChanged: (index, reason) {
+            controller.updateIndex(index);
+          },
+        ),
+        itemBuilder: (BuildContext context, int index, int realIndex) {
+          return Container(
+            margin: const EdgeInsets.symmetric(horizontal: 5.0),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: NetworkImageWithLoader(
+                imageUrl: controller.promoImages[index],
+                fit: BoxFit.cover,
+                width: double.infinity,
+              ),
+            ),
+          );
+        },
+      ),
+      // Indicator dots
+      const SizedBox(height: 10),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: controller.promoImages.asMap().entries.map((entry) {
+          return Obx(() => Container(
+                width: 8.0,
+                height: 8.0,
+                margin: const EdgeInsets.symmetric(horizontal: 4.0),
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: controller.currentIndex.value == entry.key
+                      ? Get.theme.colorScheme.primary
+                      : Colors.grey.shade300,
+                ),
+              ));
+        }).toList(),
+      ),
+    ],
+  );
+}

--- a/lib/modules/settings/settings_page/views/settings_page.dart
+++ b/lib/modules/settings/settings_page/views/settings_page.dart
@@ -79,7 +79,7 @@ class SettingsPage extends StatelessWidget {
               _buildSettingsItem(
                 title: 'Terms & Conditions',
                 onTap: () {
-                  // Navigate to Terms & Conditions Page
+                  Get.toNamed(MyRoutes.termsOfService);
                 },
                 trailing: Icon(Icons.keyboard_arrow_right),
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  carousel_slider:
+    dependency: "direct main"
+    description:
+      name: carousel_slider
+      sha256: "7b006ec356205054af5beaef62e2221160ea36b90fb70a35e4deacd49d0349ae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   characters:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   url_launcher: ^6.3.1
   flutter_secure_storage: ^9.2.4
   dio: ^5.8.0+1
+  carousel_slider: ^5.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Introduce a new promo carousel widget using the carousel_slider package to display promotional images. Also, add a blog section to showcase featured content. These changes enhance the home page's visual appeal and user engagement.